### PR TITLE
Fixes #2

### DIFF
--- a/red/focas.js
+++ b/red/focas.js
@@ -50,6 +50,8 @@ module.exports = function (RED) {
         RED.nodes.createNode(this, config);
         let node = this;
 
+        node.setMaxListeners(0);
+
         node.cncIP = config.cncIP;
         node.cncPort = Number(config.cncPort);
         node.timeout = config.timeout * 1000;


### PR DESCRIPTION
The config node must emit the STATUS event for all focas nodes that are using it. This is also the only event being emitted from the config node.

Only removing the limit itself should be enough should for fixing the issue. 